### PR TITLE
1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ mod_version=1.0.1
 mod_author=Darkorg
 mod_displayName=Serene Seasons - Pam's HarvestCraft 2: Trees Compat
 # Update versions from here
-jei_version=10.2.1.1005
-forge_version=40.2.10
-minecraft_version=1.18.2
-pamhc2trees_version=4360314
-sereneseasons_version=3804257
-mappings_version=2022.11.06-1.18.2
+jei_version=11.6.0.1016
+forge_version=43.2.14
+minecraft_version=1.19.2
+pamhc2trees_version=4480280
+sereneseasons_version=4037228
+mappings_version=2023.06.25-1.19.3
 # Gradle
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false

--- a/src/main/java/darkorg/sereneseasonsphc2trees/SeasonalTreeGrowthHandler.java
+++ b/src/main/java/darkorg/sereneseasonsphc2trees/SeasonalTreeGrowthHandler.java
@@ -1,0 +1,46 @@
+package darkorg.sereneseasonsphc2trees;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.event.level.SaplingGrowTreeEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import sereneseasons.config.FertilityConfig;
+import sereneseasons.init.ModFertility;
+import sereneseasons.init.ModTags;
+
+import static darkorg.sereneseasonsphc2trees.mixin.MixinSeasonalCropGrowthHandler.doisGlassAboveBlock;
+
+@Mod.EventBusSubscriber
+public class SeasonalTreeGrowthHandler {
+    @SubscribeEvent
+    public static void onSaplingGrowTree(SaplingGrowTreeEvent event) {
+        BlockPos pos = event.getPos();
+        Level level = (Level) event.getLevel();
+        BlockState state = level.getBlockState(pos);
+        Block block = state.getBlock();
+
+        boolean isFertile = ModFertility.isCropFertile(Registry.f_122824_.getKey(block).toString(), level, event.getPos());
+
+        if (FertilityConfig.seasonalCrops.get() && !isFertile && !doisGlassAboveBlock(level, pos)) {
+            if ((FertilityConfig.outOfSeasonCropBehavior.get() == 0) && (level.getRandom().nextInt(6) != 0)) {
+                event.setResult(Event.Result.DENY);
+            }
+            if (FertilityConfig.outOfSeasonCropBehavior.get() == 1) {
+                event.setResult(Event.Result.DENY);
+            }
+            if (FertilityConfig.outOfSeasonCropBehavior.get() == 2) {
+                if (!state.is(ModTags.Blocks.UNBREAKABLE_INFERTILE_CROPS)) {
+                    event.setResult(Event.Result.DENY);
+                    level.destroyBlock(pos, false);
+                } else {
+                    event.setResult(Event.Result.DENY);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/darkorg/sereneseasonsphc2trees/mixin/MixinBlockPamFruit.java
+++ b/src/main/java/darkorg/sereneseasonsphc2trees/mixin/MixinBlockPamFruit.java
@@ -3,6 +3,7 @@ package darkorg.sereneseasonsphc2trees.mixin;
 import com.pam.pamhc2trees.blocks.BlockPamFruit;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraftforge.common.ForgeHooks;
@@ -13,8 +14,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Random;
-
 @Mixin(BlockPamFruit.class)
 public abstract class MixinBlockPamFruit {
     @Shadow
@@ -22,7 +21,7 @@ public abstract class MixinBlockPamFruit {
     public static IntegerProperty AGE;
 
     @Inject(at = @At(value = "HEAD"), method = "randomTick", cancellable = true)
-    protected void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, Random pRandom, CallbackInfo ci) {
+    protected void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom, CallbackInfo ci) {
         if (!pLevel.isAreaLoaded(pPos, 1)) {
             return;
         }
@@ -33,7 +32,6 @@ public abstract class MixinBlockPamFruit {
 
         if (pLevel.getRawBrightness(pPos, 0) >= 9) {
             int i = pState.getValue(AGE);
-
             if (ForgeHooks.onCropsGrowPre(pLevel, pPos, pState, i < 7 && pRandom.nextInt(5) == 0)) {
                 pLevel.setBlock(pPos, pState.setValue(AGE, i + 1), 2);
                 ForgeHooks.onCropsGrowPost(pLevel, pPos, pState);

--- a/src/main/java/darkorg/sereneseasonsphc2trees/mixin/MixinSeasonalCropGrowthHandler.java
+++ b/src/main/java/darkorg/sereneseasonsphc2trees/mixin/MixinSeasonalCropGrowthHandler.java
@@ -2,49 +2,14 @@ package darkorg.sereneseasonsphc2trees.mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.event.world.SaplingGrowTreeEvent;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
-import sereneseasons.config.FertilityConfig;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import sereneseasons.handler.season.SeasonalCropGrowthHandler;
-import sereneseasons.init.ModFertility;
-import sereneseasons.init.ModTags;
 
 @Mixin(SeasonalCropGrowthHandler.class)
-public abstract class MixinSeasonalCropGrowthHandler {
-    @Shadow
-    protected abstract boolean isGlassAboveBlock(Level pLevel, BlockPos pPos);
-
-    @Unique
-    @SubscribeEvent
-    public void onSaplingGrowTree(SaplingGrowTreeEvent event) {
-        BlockPos pos = event.getPos();
-        Level level = (Level) event.getWorld();
-        BlockState state = level.getBlockState(pos);
-        Block block = state.getBlock();
-
-        boolean isFertile = ModFertility.isCropFertile(block.getRegistryName().toString(), level, pos);
-
-        if (FertilityConfig.seasonalCrops.get() && !isFertile && !isGlassAboveBlock(level, pos)) {
-            if ((FertilityConfig.outOfSeasonCropBehavior.get() == 0) && (level.getRandom().nextInt(6) != 0)) {
-                event.setResult(Event.Result.DENY);
-            }
-            if (FertilityConfig.outOfSeasonCropBehavior.get() == 1) {
-                event.setResult(Event.Result.DENY);
-            }
-            if (FertilityConfig.outOfSeasonCropBehavior.get() == 2) {
-                if (!state.is(ModTags.Blocks.UNBREAKABLE_INFERTILE_CROPS)) {
-                    event.setResult(Event.Result.DENY);
-                    event.getWorld().destroyBlock(pos, false);
-                } else {
-                    event.setResult(Event.Result.DENY);
-                }
-            }
-        }
+public interface MixinSeasonalCropGrowthHandler {
+    @Invoker("isGlassAboveBlock")
+    static boolean doisGlassAboveBlock(Level pLevel, BlockPos pPos) {
+        throw new AssertionError();
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,7 +15,7 @@ description = '''Grow your fruit trees in their respective seasons!'''
 [[dependencies.sereneseasonsphc2trees]]
 modId = "sereneseasons"
 mandatory = true
-versionRange = "[1.18.2-7.0.0.15,)"
+versionRange = "[1.19.2-8.1.0.24,)"
 ordering = "NONE"
 side = "BOTH"
 

--- a/src/main/resources/data/sereneseasons/tags/blocks/autumn_crops.json
+++ b/src/main/resources/data/sereneseasons/tags/blocks/autumn_crops.json
@@ -34,6 +34,8 @@
     "pamhc2trees:pamrambutan",
     "pamhc2trees:pamtamarind",
     "pamhc2trees:pampinenut",
+    "pamhc2trees:pamacorn",
+    "pamhc2trees:acorn_sapling",
     "pamhc2trees:apple_sapling",
     "pamhc2trees:avocado_sapling",
     "pamhc2trees:candlenut_sapling",

--- a/src/main/resources/data/sereneseasons/tags/blocks/summer_crops.json
+++ b/src/main/resources/data/sereneseasons/tags/blocks/summer_crops.json
@@ -40,6 +40,8 @@
     "pamhc2trees:pamrambutan",
     "pamhc2trees:pamtamarind",
     "pamhc2trees:pampinenut",
+    "pamhc2trees:pamacorn",
+    "pamhc2trees:acorn_sapling",
     "pamhc2trees:apple_sapling",
     "pamhc2trees:avocado_sapling",
     "pamhc2trees:candlenut_sapling",

--- a/src/main/resources/data/sereneseasons/tags/items/autumn_crops.json
+++ b/src/main/resources/data/sereneseasons/tags/items/autumn_crops.json
@@ -32,6 +32,7 @@
     "pamhc2trees:jackfruititem",
     "pamhc2trees:rambutanitem",
     "pamhc2trees:tamarinditem",
-    "pamhc2trees:pinenutitem"
+    "pamhc2trees:pinenutitem",
+    "pamhc2trees:acornitem"
   ]
 }

--- a/src/main/resources/data/sereneseasons/tags/items/summer_crops.json
+++ b/src/main/resources/data/sereneseasons/tags/items/summer_crops.json
@@ -38,6 +38,7 @@
     "pamhc2trees:passionfruititem",
     "pamhc2trees:rambutanitem",
     "pamhc2trees:tamarinditem",
-    "pamhc2trees:pinenutitem"
+    "pamhc2trees:pinenutitem",
+    "pamhc2trees:acornitem"
   ]
 }


### PR DESCRIPTION
Updated the mod to 1.19.2

The main code change required for the port was in the `MixinSeasonalCropGrowthHandler` class, specifically the `onSaplingGrowTree `event listener was moved to its own class. This was required due to SereneSeason's `SeasonalCropGrowthHandler` now being static and only registered through the `Mod.EventBusSubscriber` annotation.
> This annotation only subscribes public static functions in the class its applied to, however mixin methods (to my knowledge) cannot be public static; Thus requiring the split as we can no longer introduce the event listener into serene seasons itself.